### PR TITLE
HTML-from-markdown feature added

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,12 @@ Output: a list of all missing files.
 
 ### Creating HTML files from Markdown
 
-**Not yet implemented**
-
 The Markdown files are used to make authoring easier, but the web site requires HTML.
 
 To create HTML files from all Markdown files:
 
 ```bash
-./bin/manage_files.pl --make-html [--root-dir ./my_dir]
+./bin/manage_files.pl --md2html [--root-dir ./my_dir]
 ```
 Output: a list of all HTML files that have been created.
 

--- a/species/Acanthocheilonema_viteae/Acanthocheilonema_viteae.about.md
+++ b/species/Acanthocheilonema_viteae/Acanthocheilonema_viteae.about.md
@@ -1,2 +1,2 @@
-[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/Acanthocheilonema_viteae.about.html on Thu Jun 11 13:43:08 2020)
+[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/Acanthocheilonema_viteae.about.html on Fri Jun 12 11:03:27 2020)
 The nematode _Acanthocheilonema viteae_ is a filarial parasite of rodents. It is widely used as a model for human filariases. Importantly, _A. viteae_ lacks the Wolbachia bacterial endosymbiont found in most human-infective filarial nematodes. Thus this species has become central in efforts to understand the role of the Wolbachia in the nematode-bacterial symbiosis, and in particular its possible role in immune evasion.

--- a/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.annotation.md
+++ b/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.annotation.md
@@ -1,2 +1,2 @@
-[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.annotation.html on Thu Jun 11 13:43:08 2020)
+[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.annotation.html on Fri Jun 12 11:03:27 2020)
 The _A. viteae_ genome has been sequenced by the [Blaxter laboratory at University of Edinburgh](http://www.nematodes.org/). The assembly version represented here is nAv1.0, obtained from [nematodes.org](http://nematodes.org/genomes/acanthocheilonema_viteae/).

--- a/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.assembly.md
+++ b/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.assembly.md
@@ -1,2 +1,2 @@
-[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.assembly.html on Thu Jun 11 13:43:08 2020)
+[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.assembly.html on Fri Jun 12 11:03:27 2020)
 The _A. viteae_ genome has been sequenced by the [Blaxter laboratory at University of Edinburgh](http://www.nematodes.org/). The assembly version represented here is nAv1.0, obtained from [nematodes.org](http://nematodes.org/genomes/acanthocheilonema_viteae/).

--- a/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.summary.md
+++ b/species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.summary.md
@@ -1,2 +1,2 @@
-[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.summary.html on Thu Jun 11 13:43:07 2020)
+[//]: # (Created by ./bin/manage_files.pl from ./species/Acanthocheilonema_viteae/PRJEB1697/Acanthocheilonema_viteae_PRJEB1697.summary.html on Fri Jun 12 11:03:27 2020)
 University of Edinburgh


### PR DESCRIPTION
- `manage-files.pl --md2html' will create HTML from markdown wherever the HTML file is missing or empty, and a non-empty markdown file exists
- updated README